### PR TITLE
Don't pull lfs always

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 Native OBS SCM bridge helper
 ============================
 
-Native OBS scm support for the build recipies and additional files. This is bridging an external authorative
-scm repository into OBS. Any source change or merge workflow must be provided via the scm repository 
+Native OBS scm support for the build recipies and additional files. This is bridging an external authoritative
+scm repository into OBS. Any source change or merge workflow must be provided via the scm repository
 hoster in this scenario.
 
 Only git is supported atm, but this can be extended later to further systems.
@@ -14,6 +14,10 @@ asset support instead, which is described in pbuild documentation:
   http://opensuse.github.io/obs-build/pbuild.html#_remote_assets
 
 These assets will be downloaded by osc and OBS. The verification via sha256 sum is optional.
+
+Alternatively, put large binary files into
+[git-lfs](https://git-lfs.github.com/). This service will automatically download
+git-lfs assets.
 
 HOWTO manage a single package
 =============================
@@ -43,7 +47,7 @@ HOWTO manage an entire project
 A git repository can also get defined for entire project. This can be done
 via the scmsync element in project meta.
 
-Any top level subdirectory will be handled as package container. 
+Any top level subdirectory will be handled as package container.
 
 It is recomended to use git submodules for each package if it is a larger
 project. This allows partial cloning of the specific package.
@@ -54,7 +58,7 @@ Special directives
 Special directives can be given via cgi parameters to the bridge. Extend
 your url with
 
- * lfs=1 CGI parameter to include LFS resources
+ * `lfs=0` to skip downloading LFS assets
 
  * arch=<ARCH> CGI parameter to specify arch specific assets downloads
 

--- a/obs-scm-bridge.spec
+++ b/obs-scm-bridge.spec
@@ -31,7 +31,8 @@ Source0:        %{name}-%{version}.tar.xz
 Requires:       %{build_pkg_name} >= 20211125
 BuildArch:      noarch
 Recommends:     python3-packaging
-
+Requires:       git
+Requires:       git-lfs
 
 %description
 

--- a/obs_scm_bridge
+++ b/obs_scm_bridge
@@ -20,7 +20,7 @@ import logging
 import subprocess
 import tempfile
 from html import escape
-from typing import TYPE_CHECKING, List, Optional, TextIO, Tuple, Union, overload
+from typing import TYPE_CHECKING, Dict, List, Optional, TextIO, Tuple, Union, overload
 if TYPE_CHECKING:
     from typing import Literal
 import urllib.parse
@@ -83,6 +83,7 @@ class ObsGit(object):
             fatal: str,
             cwd: Optional[str]=None,
             stdout: Union[int, TextIO]=subprocess.PIPE,
+            env: Optional[Dict[str, str]]=None,
     ) -> Tuple["Literal[0]", Optional[str]]: ...
 
     @overload
@@ -93,6 +94,7 @@ class ObsGit(object):
             fatal: Optional[str]=None,
             cwd: Optional[str]=None,
             stdout: Union[int, TextIO]=subprocess.PIPE,
+            env: Optional[Dict[str, str]]=None,
     ) -> Tuple[int, Optional[str]]: ...
 
     def run_cmd(
@@ -102,6 +104,7 @@ class ObsGit(object):
             fatal: Optional[str]=None,
             cwd: Optional[str]=None,
             stdout: Union[int, TextIO]=subprocess.PIPE,
+            env: Optional[Dict[str, str]]=None,
     ) -> Tuple[int, Optional[str]]:
         logging.debug("COMMAND: %s" % cmd)
         stderr = subprocess.PIPE
@@ -111,7 +114,8 @@ class ObsGit(object):
                                 shell=False,
                                 stdout=stdout,
                                 stderr=stderr,
-                                cwd=cwd)
+                                cwd=cwd,
+                                env=env)
         std_out = proc.communicate()[0]
         output = std_out.decode() if std_out else None
 

--- a/obs_scm_bridge
+++ b/obs_scm_bridge
@@ -83,7 +83,7 @@ class ObsGit(object):
             fatal: str,
             cwd: Optional[str]=None,
             stdout: Union[int, TextIO]=subprocess.PIPE,
-    ) -> Tuple["Literal[0]", str]: ...
+    ) -> Tuple["Literal[0]", Optional[str]]: ...
 
     @overload
     def run_cmd(
@@ -93,7 +93,7 @@ class ObsGit(object):
             fatal: Optional[str]=None,
             cwd: Optional[str]=None,
             stdout: Union[int, TextIO]=subprocess.PIPE,
-    ) -> Tuple[int, str]: ...
+    ) -> Tuple[int, Optional[str]]: ...
 
     def run_cmd(
             self,
@@ -102,7 +102,7 @@ class ObsGit(object):
             fatal: Optional[str]=None,
             cwd: Optional[str]=None,
             stdout: Union[int, TextIO]=subprocess.PIPE,
-    ) -> Tuple[int, str]:
+    ) -> Tuple[int, Optional[str]]:
         logging.debug("COMMAND: %s" % cmd)
         stderr = subprocess.PIPE
         if stdout == subprocess.PIPE:
@@ -112,7 +112,9 @@ class ObsGit(object):
                                 stdout=stdout,
                                 stderr=stderr,
                                 cwd=cwd)
-        output = proc.communicate()[0].decode("utf-8")
+        std_out = proc.communicate()[0]
+        output = std_out.decode() if std_out else None
+
         logging.debug("RESULT(%d): %s", proc.returncode, repr(output))
         if fatal and proc.returncode != 0:
             print("ERROR: " + fatal + " failed: ", output)

--- a/obs_scm_bridge
+++ b/obs_scm_bridge
@@ -82,9 +82,7 @@ class ObsGit(object):
                                 stdout=stdout,
                                 stderr=stderr,
                                 cwd=cwd)
-        output = proc.communicate()[0]
-        if isinstance(output, bytes):
-            output = output.decode('UTF-8')
+        output = proc.communicate()[0].decode("utf-8")
         logging.debug("RESULT(%d): %s", proc.returncode, repr(output))
         if fatal and proc.returncode != 0:
             print("ERROR: " + fatal + " failed: ", output)

--- a/obs_scm_bridge
+++ b/obs_scm_bridge
@@ -20,6 +20,9 @@ import logging
 import subprocess
 import tempfile
 from html import escape
+from typing import TYPE_CHECKING, List, Optional, TextIO, Tuple, Union, overload
+if TYPE_CHECKING:
+    from typing import Literal
 import urllib.parse
 import configparser
 
@@ -72,7 +75,34 @@ class ObsGit(object):
             self.revision = self.url[5]
             self.url[5] = ''
 
-    def run_cmd(self, cmd, cwd=None, stdout=subprocess.PIPE, fatal=None):
+    @overload
+    def run_cmd(
+            self,
+            cmd: List[str],
+            *,
+            fatal: str,
+            cwd: Optional[str]=None,
+            stdout: Union[int, TextIO]=subprocess.PIPE,
+    ) -> Tuple["Literal[0]", str]: ...
+
+    @overload
+    def run_cmd(
+            self,
+            cmd: List[str],
+            *,
+            fatal: Optional[str]=None,
+            cwd: Optional[str]=None,
+            stdout: Union[int, TextIO]=subprocess.PIPE,
+    ) -> Tuple[int, str]: ...
+
+    def run_cmd(
+            self,
+            cmd: List[str],
+            *,
+            fatal: Optional[str]=None,
+            cwd: Optional[str]=None,
+            stdout: Union[int, TextIO]=subprocess.PIPE,
+    ) -> Tuple[int, str]:
         logging.debug("COMMAND: %s" % cmd)
         stderr = subprocess.PIPE
         if stdout == subprocess.PIPE:

--- a/obs_scm_bridge
+++ b/obs_scm_bridge
@@ -48,12 +48,12 @@ class ObsGit(object):
         self.outdir   = outdir
         self.revision = None
         self.subdir   = None
-        self.lfs = False
         self.keep_meta = False
         self.enforced_deep_clone = False
         self.arch = []
         self.url = list(urllib.parse.urlparse(url))
-        query = urllib.parse.parse_qs(self.url[4]);
+        self.no_lfs = False
+        query = urllib.parse.parse_qs(self.url[4])
         if "subdir" in query:
             self.subdir = query['subdir'][0]
             del query['subdir']
@@ -62,14 +62,14 @@ class ObsGit(object):
             self.arch = query['arch']
             del query['arch']
             self.url[4] = urllib.parse.urlencode(query)
-        if "lfs" in query:
-            self.lfs = True
-            del query['lfs']
-            self.url[4] = urllib.parse.urlencode(query)
         if "keepmeta" in query:
             self.enforced_deep_clone = True
             self.keep_meta = True
             del query['keepmeta']
+            self.url[4] = urllib.parse.urlencode(query)
+        if "lfs" in query:
+            self.no_lfs = query["lfs"] == ["0"]
+            del query["lfs"]
             self.url[4] = urllib.parse.urlencode(query)
         if self.url[5]:
             self.revision = self.url[5]
@@ -125,10 +125,6 @@ class ObsGit(object):
             sys.exit(proc.returncode)
         return (proc.returncode, output)
 
-    def do_lfs(self, outdir):
-        cmd = [ 'git', '-C', outdir, 'lfs', 'fetch' ]
-        self.run_cmd(cmd, fatal="git lfs fetch")
-
     def do_clone_commit(self, outdir, include_submodules=False):
         cmd = [ 'git', 'init', outdir ]
         self.run_cmd(cmd, fatal="git init")
@@ -141,7 +137,8 @@ class ObsGit(object):
             cmd += [ '--recurse-submodules' ]
         self.run_cmd(cmd, fatal="git fetch")
         cmd = [ 'git', '-C', outdir, 'checkout', '-q', self.revision ]
-        self.run_cmd(cmd, fatal="git checkout")
+        env = {"GIT_LFS_SKIP_SMUDGE": "1", **os.environ} if self.no_lfs else None
+        self.run_cmd(cmd, fatal="git checkout", env=env)
         if include_submodules:
             cmd = [ 'git', '-C', outdir, 'submodule', 'init' ]
             self.run_cmd(cmd, fatal="git submodule init")
@@ -151,8 +148,6 @@ class ObsGit(object):
     def do_clone(self, outdir, shallow, include_submodules=False):
         if self.revision and re.match(r"^[0-9a-fA-F]{40,}$", self.revision):
             self.do_clone_commit(outdir, include_submodules)
-            if self.lfs:
-                self.do_lfs(outdir)
             return
         cmd = [ 'git', 'clone', urllib.parse.urlunparse(self.url), outdir ]
         if include_submodules:
@@ -162,9 +157,8 @@ class ObsGit(object):
         if self.revision:
             cmd.insert(2, '-b')
             cmd.insert(3, self.revision)
-        self.run_cmd(cmd, fatal="git clone")
-        if self.lfs:
-            self.do_lfs(outdir)
+        env = {"GIT_LFS_SKIP_SMUDGE": "1", **os.environ} if self.no_lfs else None
+        self.run_cmd(cmd, fatal="git clone", env=env)
 
     def clone(self, shallow_clone, include_submodules=False):
         if not self.subdir:

--- a/obs_scm_bridge
+++ b/obs_scm_bridge
@@ -103,7 +103,6 @@ class ObsGit(object):
             cmd += [ '--depth', '1' ]
         if include_submodules:
             cmd += [ '--recurse-submodules' ]
-        print(cmd)
         self.run_cmd(cmd, fatal="git fetch")
         cmd = [ 'git', '-C', outdir, 'checkout', '-q', self.revision ]
         self.run_cmd(cmd, fatal="git checkout")


### PR DESCRIPTION
When git-lfs is installed, then lfs archives will be always downloaded as well,
which is in contrast to the documentation which says that this will only happen
when the query `lfs=1` is present in the URL. To prevent lfs archives from being
pulled, we clone the repository with the environment variable
GIT_LFS_SKIP_SMUDGE set to 1, which prevents automatic downloads (see
https://stackoverflow.com/a/42021818).

Additionally, we have to use `git lfs pull` instead of `git lfs fetch` as fetch
does not replace the placeholder text files with the binaries, it only retrieves
them.