### PR TITLE
git-lfs is actually available on Centos as well

### DIFF
--- a/obs-scm-bridge.spec
+++ b/obs-scm-bridge.spec
@@ -29,6 +29,7 @@ License:        GPL-2.0-or-later
 URL:            https://github.com/openSUSE/obs-scm-bridge
 Source0:        %{name}-%{version}.tar.xz
 Requires:       %{build_pkg_name} >= 20211125
+Requires:       git-lfs
 # these are just recommends in build package, but we need it here
 Requires:       perl(Date::Parse)
 Requires:       perl(LWP::UserAgent)
@@ -44,7 +45,6 @@ BuildArch:      noarch
 Requires:       git
 %else
 Requires:       git-core
-Requires:       git-lfs
 %endif
 
 %description


### PR DESCRIPTION
so we can unconditionally require it