### PR TITLE
Allow to extract only defined subpackages via onlybuild

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,16 @@ your url with
 
  * subdir=<DIRECTORY> CGI parameter to package only a subdirectory
 
+Special directives for entire projects
+======================================
+
+ * projectmode=1 is switching project mode on. The bridge will just prepare
+                 package meta files for each subdirectory.
+
+ * onlybuild=<DIRECTORY> can be used to specify to only export defined packages
+                         without modifing the git source. The parameter can be
+                         used multiple times to collect multiple.
+
 TODO
 ====
 

--- a/obs_scm_bridge
+++ b/obs_scm_bridge
@@ -52,6 +52,7 @@ class ObsGit(object):
         self.keep_meta = False
         self.enforced_deep_clone = False
         self.arch = []
+        self.onlybuild = None
         self.url = list(urllib.parse.urlparse(url))
         self.no_lfs = False
         # for project level mode
@@ -76,6 +77,11 @@ class ObsGit(object):
         if "lfs" in query:
             self.no_lfs = query["lfs"] == ["0"]
             del query["lfs"]
+            self.url[4] = urllib.parse.urlencode(query)
+        if "onlybuild" in query:
+            ob = query['onlybuild']
+            self.onlybuild={ob[i]:1 for i in range(len(ob))}
+            del query['onlybuild']
             self.url[4] = urllib.parse.urlencode(query)
         if self.url[5]:
             self.revision = self.url[5]
@@ -328,6 +334,8 @@ class ObsGit(object):
 
     def write_package_xml_file(self, name: str, url: str, projectscmsync: str=None) -> None:
         projecturlxml=''
+        if self.onlybuild and not name in self.onlybuild.keys():
+            return
         if projectscmsync:
             projecturlxml=f"""\n  <url>{escape(projectscmsync)}</url>"""
         with open(f"{name}.xml", 'w') as xmlfile:


### PR DESCRIPTION
This allows to build only a specific set of packagfes from a larger project git. This allows to test build just a few packages in a QA project without the need to modify the git source.

The onlybuild parameter is used to be similar to obs build config.