### PR TITLE
Follow submodule branch when cloning via osc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ your url with
 
  * noobsinfo=1 do not write a `_scmsync.obsinfo` file
 
+ * trackingbranch=BRANCH may be used to clone the branch instead of a revision.
+                         information is taken from .gitmodules if available.
+
 Special directives for entire projects
 ======================================
 

--- a/obs_scm_bridge
+++ b/obs_scm_bridge
@@ -30,6 +30,7 @@ critical_instances_config = "/etc/obs/services/scm-bridge/critical-instances"
 credentials_config = "/etc/obs/services/scm-bridge/credentials"
 export_debian_orig_from_git = '/usr/lib/build/export_debian_orig_from_git'
 pack_directories = False
+follow_tracking_branch = False
 get_assets = False
 shallow_clone = True
 create_obsinfo = False
@@ -50,6 +51,7 @@ if os.environ.get('OSC_VERSION'):
     shallow_clone = False
     create_obsinfo = False
     rewrite_url_to_ssh = True
+    follow_tracking_branch = True
 os.environ['LANG'] = "C"
 
 class ObsGit(object):
@@ -114,6 +116,11 @@ class ObsGit(object):
         if self.url[5]:
             self.revision = self.url[5]
             self.url[5] = ''
+        if 'trackingbranch' in query:
+            if follow_tracking_branch:
+                self.revision = query['trackingbranch'][0]
+            del query['trackingbranch']
+            self.url[4] = urllib.parse.urlencode(query, doseq=True)
         # we cannot keep the meta in subdir mode and we can always
         # do a shallow clone
         if self.subdir:
@@ -560,11 +567,15 @@ class ObsGit(object):
 
         revision = revisions.get(gsmsection['path'])
         if not revision:
-            self.die("could not determine revision of submodule for {gsmsection['path']}")
+            self.die(f"could not determine revision of submodule for {gsmsection['path']}")
 
         # write xml file and register the module
         url = list(urllib.parse.urlparse(urlstr))
         url[5] = revision
+        if 'branch' in gsmsection:
+            query = urllib.parse.parse_qs(url[4], keep_blank_values=True);
+            query['trackingbranch'] = [gsmsection['branch']]
+            url[4] = urllib.parse.urlencode(query, doseq=True)
         if self.arch:
             query = urllib.parse.parse_qs(url[4], keep_blank_values=True);
             query['arch'] = self.arch


### PR DESCRIPTION
For that we need to export the configured tracking branch from .gitmodules and hand it over to the package scmsync url.

We may should do the switching to use the branch via an explicit CLI switch from osc side.
Or should be offer a disable switch instead?

@dmach any opinion?